### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,35 +1,38 @@
-0.10 Mon. Sep 30, 2013
+Revision history for Perl module K
+
+0.10 2013-09-30
     - Stop including k.h to minimize the chances of a k.h / c.o conflict.
     - Set KXVER variable during build.
     - Fix bug where test suite hangs with newer qs.
 
-0.09 Wed. Apr 25, 2012
+0.09 2012-04-25
     - Throw an exception if no arg is passed to K->cmd or K->async_cmd
 
-0.08 Wed. Apr 25, 2012
+0.08 2012-04-25
     - Fix bug where null values in q dictionaries causes a segfault
 
-0.07 Sun. Apr 22, 2012
+0.07 2012-04-22
     - Support connection timeouts
     - Represent paritioned tables and unparttioned tables the same way
 
-0.06 Sun. Apr 08, 2012
+0.06 2012-04-08
     - Provide mechansim for receiving messages
     - Improve error detection and reporting
     - Support Perls with and without native 64-bit ints
 
-0.05 Thu. Apr 05, 2012
+0.05 2012-04-05
     - Make sure version and abstract are set properly
 
-0.04 Tue. Mar 27, 2012
+0.04 2012-03-27
     - Handle undocumented K struct types 100,102, and 103
 
-0.03 Mon. Mar 26, 2012
+0.03 2012-03-26
     - Handle nulls and infinites
     - Fix a couple memory leaks
     - Make build work on 64-bit Linux
     - Support asynchronous commands in OO interface
 
-0.02 Mon. Mar 26, 2012
+0.02 2012-03-26
     - Improve docs
     - Declare Moose dependency in Makefile.PL
+


### PR DESCRIPTION
Hi Whitney,

I've updated your Changes file to follow the format defined in CPAN::Changes::Spec:
- Added a header line identifying the file / module
- Changed dates to the ISO 8601 date format

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086
